### PR TITLE
refactor: re-export `jsonwebtoken` structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "tower-jwt"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-jwt"
 description = "Tower middleware to parse JWTs on Authorization Bearers"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 repository = "https://github.com/shuttle-hq/tower-jwt"
 documentation = "https://docs.rs/tower-jwt"

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ This is build on top of the [jsonwebtoken](https://docs.rs/jsonwebtoken) crate a
 Since this is a Tower middleware it can be used on any framework like Axum, Tonic, etc.
 
 # Symmetric example using Hyper
+This example show how to use the re-exported `DecodingKey` and `Validation` from `jsonwebtoken` to parse and validate a JWT setup with a simple symmetric secret. It also show how to customize the default validator and how to extract both registered and public fields on a claim.
 
 ``` rust
 use chrono::{DateTime, Utc};
 use http::{header::AUTHORIZATION, Request, Response, StatusCode};
 use http_body_util::Empty;
-use jsonwebtoken::{DecodingKey, Validation};
 use serde::Deserialize;
 use std::convert::Infallible;
 use tower::{Service, ServiceBuilder, ServiceExt};
-use tower_jwt::{JwtLayer, RequestClaim};
+use tower_jwt::{DecodingKey, JwtLayer, RequestClaim, Validation};
 
 // Setup your claim with the fields you want to extract
 #[derive(Clone, Deserialize, Debug)]
@@ -101,14 +101,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 use axum::{routing::get, Extension, Router};
 use http::{Request, StatusCode};
 use http_body_util::Empty;
-use jsonwebtoken::{DecodingKey, Validation};
 use ring::{
     rand,
     signature::{self, Ed25519KeyPair, KeyPair},
 };
 use serde::Deserialize;
 use tower::ServiceExt;
-use tower_jwt::{JwtLayer, RequestClaim};
+use tower_jwt::{DecodingKey, JwtLayer, RequestClaim, Validation};
 
 // Setup your claim with the fields you want to extract
 #[derive(Deserialize, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@ use std::{convert::Infallible, future::Future, marker::PhantomData, pin::Pin, ta
 use async_trait::async_trait;
 use headers::{authorization::Bearer, Authorization, HeaderMapExt};
 use http::{Request, Response, StatusCode};
-use jsonwebtoken::{decode, DecodingKey, Validation};
+use jsonwebtoken::decode;
+pub use jsonwebtoken::{DecodingKey, Validation};
 use pin_project::pin_project;
 use serde::Deserialize;
 use tower::{Layer, Service};


### PR DESCRIPTION
This makes it easier for users as they don't have to add a `jsonwebtoken` dependency too.